### PR TITLE
Fix TypeScript syntax and add non-null assertion

### DIFF
--- a/plop-templates/Component.tsx.hbs
+++ b/plop-templates/Component.tsx.hbs
@@ -1,6 +1,6 @@
 import styles from './{{pascalCase name}}.module.scss';
 
-interface {{pascalCase name}}Props = {
+interface {{pascalCase name}}Props {
   prop: string;
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,7 +6,7 @@ import App from './App.js';
 import { runMockServer } from './mocks/server';
 
 runMockServer().then(() => {
-  createRoot(document.getElementById('root')).render(
+  createRoot(document.getElementById('root')!).render(
     <StrictMode>
       <App />
     </StrictMode>,


### PR DESCRIPTION
Corrected a syntax error in the TypeScript interface definition within the Plop template. Added a non-null assertion operator to ensure the root DOM element is not null during rendering in the main entry point.